### PR TITLE
Initial implementation of blocksparse `exp` and its performance results

### DIFF
--- a/torchinductor/triton_ops/blocksparse/exp.py
+++ b/torchinductor/triton_ops/blocksparse/exp.py
@@ -107,7 +107,7 @@ def _exp_kernel(x_rowptrs, x_cols, x_data, y_data,
     tl.store(y_offsets, block)
 
 
-def exp(x_mask: RaggedFormat, x_data):
+def kernel(x_mask: RaggedFormat, x_data):
     '''
     Launch a 2D grid to do the computation.
 
@@ -124,6 +124,6 @@ def exp(x_mask: RaggedFormat, x_data):
     )
     # Same mask is used for y
     y_mask = x_mask.copy()
-    y_mask.default = 1
+    y_mask.default = torch.exp(x_mask.default)
     return (y_mask, y_data)
 

--- a/torchinductor/triton_ops/blocksparse/exp.py
+++ b/torchinductor/triton_ops/blocksparse/exp.py
@@ -1,5 +1,6 @@
 import sys
 import torch
+import numpy as np
 import triton 
 import triton.language as tl
 from torchinductor.triton_ops.blocksparse.utils import *
@@ -124,6 +125,6 @@ def kernel(x_mask: RaggedFormat, x_data):
     )
     # Same mask is used for y
     y_mask = x_mask.copy()
-    y_mask.default = torch.exp(x_mask.default)
+    y_mask.default = np.exp(x_mask.default)
     return (y_mask, y_data)
 

--- a/torchinductor/triton_ops/blocksparse/exp.py
+++ b/torchinductor/triton_ops/blocksparse/exp.py
@@ -127,15 +127,3 @@ def exp(x_mask: RaggedFormat, x_data):
     y_mask.default = 1
     return (y_mask, y_data)
 
-
-
-# def sum_kernel(a, default_value):
-#     m = ...
-#     num_zeros = N - nnz_of_the_row * block_dim
-#     tl.sum(row) + default_value * num_of_zeros
-
-#     if (n >= col_end) | (n < col_start):
-#         return [BLOCK_N,
-#             BLOCK_N,
-#             ...
-#         ]

--- a/torchinductor/triton_ops/blocksparse/exp.py
+++ b/torchinductor/triton_ops/blocksparse/exp.py
@@ -1,0 +1,141 @@
+import sys
+import torch
+import triton 
+import triton.language as tl
+from torchinductor.triton_ops.blocksparse.utils import *
+
+
+@triton.jit
+def _exp_1d_kernel(x_rowptrs, x_cols, x_data, y_data, 
+                M: tl.constexpr, N: tl.constexpr,
+                BM: tl.constexpr, BN: tl.constexpr,
+                # tile sizes, BM needs to divide TM etc
+                TM: tl.constexpr, TN: tl.constexpr, 
+                use_dense_data: tl.constexpr
+                ):
+    m = tl.program_id(0)
+    block_size = BM * BN
+
+    ## Format specific: how to get `k` would depend on the format
+    col_start = tl.load(x_cols + 2*m)
+    col_end = tl.load(x_cols + 2*m+1)
+
+    offsets = 0
+    ## If data layout is dense - good for debugging
+    if use_dense_data:
+        offsets += m * BM * N 
+    else:
+        # TODO: add indexing for sparse data blocks
+        pass
+    offsets += tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :] 
+    x_offsets = x_data + offsets
+    y_offsets = y_data + offsets
+
+    for _ in range(col_start, col_end):
+        ## Format specific: how to get `k` would depend on the format
+        block = tl.load(x_offsets)
+        
+        ## Kernel specific
+        block = tl.exp(block)
+        
+        ## Format specific: how to get `k` would depend on the format
+        tl.store(y_offsets, block)
+        x_offsets += block_size
+        y_offsets += block_size
+
+
+def exp_1d(x_mask: RaggedFormat, x_data):
+    '''
+    Launch a 1D grid to do the computation (blocking rows only).
+
+    2x slower than the 2D blocking kernel for dense matrices of shape > 4096 x 4096.
+    '''
+    B, m, n, BM, BN = x_data.shape
+    M = m * BM
+    N = n * BN
+    y_data = torch.empty_like(x_data)
+    ## Grid size: not blocking the columns. Tow few thread blocks?
+    grid = (m, B)    
+    _exp_1d_kernel[grid](
+        x_mask.rowptrs, x_mask.cols, x_data, y_data,
+        M, N, BM, BN, BM, BN, True
+    )
+    # Same mask is used for y
+    return (x_mask, y_data)
+
+
+
+@triton.jit
+def _exp_kernel(x_rowptrs, x_cols, x_data, y_data, 
+                M: tl.constexpr, N: tl.constexpr,
+                BM: tl.constexpr, BN: tl.constexpr,
+                # tile sizes, BM needs to divide TM etc
+                TM: tl.constexpr, TN: tl.constexpr, 
+                use_dense_data: tl.constexpr
+                ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    
+    ## Format specific: how to get `k` would depend on the format
+    col_start = tl.load(x_cols + 2*m)
+    col_end = tl.load(x_cols + 2*m+1)
+    ## Skip the computation if not a nonzero
+    if (n >= col_end) | (n < col_start):
+        return 
+
+    block_size = BM * BN
+
+    offsets = 0
+    ## If data layout is dense - good for debugging
+    if use_dense_data:
+        offsets += m * BM * N 
+    else:
+        # TODO: add indexing for sparse data blocks
+        pass
+    offsets += tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :] 
+    offsets += n * block_size
+    x_offsets = x_data + offsets
+    y_offsets = y_data + offsets
+
+    ## Format specific: how to get `k` would depend on the format
+    block = tl.load(x_offsets)
+    
+    ## Kernel specific
+    block = tl.exp(block)
+    
+    ## Format specific: how to get `k` would depend on the format
+    tl.store(y_offsets, block)
+
+
+def exp(x_mask: RaggedFormat, x_data):
+    '''
+    Launch a 2D grid to do the computation.
+
+    Achieved comparable performance with torch.exp for dense matrices of shape > 4096 x 4096.
+    '''
+    B, m, n, BM, BN = x_data.shape
+    M = m * BM
+    N = n * BN
+    y_data = torch.empty_like(x_data)
+    grid = (m, n, B)    
+    _exp_kernel[grid](
+        x_mask.rowptrs, x_mask.cols, x_data, y_data,
+        M, N, BM, BN, BM, BN, True
+    )
+    # Same mask is used for y
+    y_mask = x_mask.copy()
+    y_mask.default = 1
+    return (y_mask, y_data)
+
+
+
+# def sum_kernel(a, default_value):
+#     m = ...
+#     num_zeros = N - nnz_of_the_row * block_dim
+#     tl.sum(row) + default_value * num_of_zeros
+
+#     if (n >= col_end) | (n < col_start):
+#         return [BLOCK_N,
+#             BLOCK_N,
+#             ...
+#         ]

--- a/torchinductor/triton_ops/blocksparse/tests/test_exp.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_exp.py
@@ -6,7 +6,7 @@ from torchinductor.triton_ops.blocksparse.exp import exp
 
 VERBOSE = False
 
-def bench_exp(a): 
+def bench_triton_exp(a): 
     times = []
     for BM in [16, 32, 64]:
         for BN in [16, 32, 64]:
@@ -30,35 +30,27 @@ def bench_exp(a):
     return times[0][0]
 
 
-def test_dense():
+def bench_exp(a):
+    B, M, N = a.shape
+    ms0, _, _ = triton.testing.do_bench(lambda: torch.exp(a))
+    ms1 = bench_triton_exp(a)
+    print(f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep=';')
+
+
+def test_tril_and_dense():
     dtype = torch.float32 
     for B in [1]:
         for M in [1024, 2048, 4096]:
             for N in [1024, 2048, 4096]:
                 a = torch.randn([B, M, N], dtype=dtype, device='cuda')
-                ms0, _, _ = triton.testing.do_bench(lambda: torch.exp(a))
-                ms1 = bench_exp(a)
-                print(f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep=';')
-
-
-def test_lower_triangular():
-    dtype = torch.float32 
-    for B in [1]:
-        for M in [1024, 2048, 4096]:
-            for N in [1024, 2048, 4096]:
-                a = torch.randn([B, M, N], dtype=dtype, device='cuda')
+                print('test dense')
+                bench_exp(a)
+                print('test lower triangular')
                 a = torch.tril(a)
-                ms0, _, _ = triton.testing.do_bench(lambda: torch.exp(a))
-                ms1 = bench_exp(a)
-                print(f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep=';')
-                
+                bench_exp(a)
 
 
 if '-v' in sys.argv:
     VERBOSE = True
 
-print('test dense')
-test_dense()
-print('test lower tri')
-test_lower_triangular()
-
+test_tril_and_dense()

--- a/torchinductor/triton_ops/blocksparse/tests/test_exp.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_exp.py
@@ -12,6 +12,7 @@ def bench_triton_exp(a):
         for BN in [16, 32, 64]:
             a_data, a_mask = to_block_format_with_mask_bmm_one_mask(a, BM, BN)
             a_mask = RaggedFormat.from_dense_mask(a_mask)
+            a_mask.default = -torch.inf
             b_mask, b_data = kernel(a_mask, a_data)
             b_dense = b_mask.to_dense(b_data)
             assert torch.allclose(torch.exp(a), b_dense), \

--- a/torchinductor/triton_ops/blocksparse/tests/test_exp.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_exp.py
@@ -1,0 +1,64 @@
+import sys
+import torch
+import triton 
+from torchinductor.triton_ops.blocksparse.utils import *
+from torchinductor.triton_ops.blocksparse.exp import exp
+
+VERBOSE = False
+
+def bench_exp(a): 
+    times = []
+    for BM in [16, 32, 64]:
+        for BN in [16, 32, 64]:
+            a_data, a_mask = to_block_format_with_mask_bmm_one_mask(a, BM, BN)
+            a_mask = RaggedFormat.from_dense_mask(a_mask)
+            b_mask, b_data = exp(a_mask, a_data)
+            b_dense = b_mask.to_dense(b_data)
+            assert torch.allclose(torch.exp(a), b_dense), \
+                (torch.exp(a)[0,0], b_dense[0,0])
+            for num_warps in [2,4,8]:
+                for num_stages in  [2,3,4]:
+                    try:
+                        ms0, _, _ = triton.testing.do_bench(lambda: exp(a_mask, a_data), rep=50)
+                    except Exception as e:
+                        print(e)
+                    else:
+                        times.append((ms0, BM, BN, num_warps, num_stages))
+                        if VERBOSE:
+                            print((ms0, BM, BN, num_warps, num_stages))
+    times.sort(key=lambda x: x[0])
+    return times[0][0]
+
+
+def test_dense():
+    dtype = torch.float32 
+    for B in [1]:
+        for M in [1024, 2048, 4096]:
+            for N in [1024, 2048, 4096]:
+                a = torch.randn([B, M, N], dtype=dtype, device='cuda')
+                ms0, _, _ = triton.testing.do_bench(lambda: torch.exp(a))
+                ms1 = bench_exp(a)
+                print(f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep=';')
+
+
+def test_lower_triangular():
+    dtype = torch.float32 
+    for B in [1]:
+        for M in [1024, 2048, 4096]:
+            for N in [1024, 2048, 4096]:
+                a = torch.randn([B, M, N], dtype=dtype, device='cuda')
+                a = torch.tril(a)
+                ms0, _, _ = triton.testing.do_bench(lambda: torch.exp(a))
+                ms1 = bench_exp(a)
+                print(f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep=';')
+                
+
+
+if '-v' in sys.argv:
+    VERBOSE = True
+
+print('test dense')
+test_dense()
+print('test lower tri')
+test_lower_triangular()
+

--- a/torchinductor/triton_ops/blocksparse/utils.py
+++ b/torchinductor/triton_ops/blocksparse/utils.py
@@ -135,6 +135,8 @@ def to_block_format_with_mask_bmm_one_mask(a, BLOCK_M: int, BLOCK_N: int):
             res[:, m, n, 0: BLOCK_M, 0: BLOCK_N] = block
             if torch.count_nonzero(block) == 0:
                 mask[m, n] = 0
+            elif torch.all(block == -torch.inf):
+                mask[m, n] = 0
     return (res, mask)
 
 

--- a/torchinductor/triton_ops/blocksparse/utils.py
+++ b/torchinductor/triton_ops/blocksparse/utils.py
@@ -1,0 +1,329 @@
+import sys
+import torch
+import triton
+
+class BCSR():
+    def __init__(self, rowptrs, cols, vals) -> None:
+        self.rowptrs = rowptrs
+        self.cols = cols
+        self.vals = vals
+
+
+class RaggedFormat:
+    def __init__(self, rowptrs, cols, default=0):
+        self.rowptrs = rowptrs
+        self.cols = cols
+        self.default = default
+
+    def from_dense_mask(mask, default=0) -> None:        
+        rowptrs, cols = to_ragged_format_simple(mask)
+        return RaggedFormat(rowptrs, cols, default)
+
+    def copy(self):
+        c = RaggedFormat(self.rowptrs, self.cols, self.default)
+        return c
+
+    def to_dense(self, a):
+        '''
+        Return a dense representation of `a`.
+        '''
+        B, m, n, BLOCK_M, BLOCK_N = a.shape
+
+        M = m * BLOCK_M
+        N = n * BLOCK_N
+
+        res = torch.zeros((B, M, N), dtype=a.dtype, device=a.device)
+
+        for i in range(m):
+            col_start = self.cols[2*i]
+            col_end = self.cols[2*i+1]
+            for j in range(n):
+                if j < col_start or j >= col_end:
+                    block = torch.empty([B, BLOCK_M, BLOCK_N], dtype=a.dtype, device=a.device)
+                    block.fill_(self.default)
+                else:
+                    block = a[:, i, j, 0: BLOCK_M, 0: BLOCK_N]
+
+                res[
+                    :,
+                    i * BLOCK_M: (i+1) * BLOCK_M, 
+                    j * BLOCK_N: (j+1) * BLOCK_N
+                ] = block
+
+        return res
+        
+
+def cdiv(x, y):
+    return (x + y -1) // y
+
+
+def to_block_format(a, BLOCK_M: int, BLOCK_N: int):
+    M, N = a.shape
+    outer_m_dim = cdiv(M, BLOCK_M)
+    outer_n_dim = cdiv(N, BLOCK_N)
+    inner_m_dim = BLOCK_M
+    inner_n_dim = BLOCK_N
+
+    res = torch.empty(
+        (outer_m_dim, outer_n_dim, inner_m_dim, inner_n_dim),
+        dtype=a.dtype,
+        device=a.device,
+    )
+
+    # TODO - Implement/check for padding
+    for outer_m in range(outer_m_dim):
+        for outer_n in range(outer_n_dim):
+            res[outer_m, outer_n, 0: inner_m_dim, 0: inner_n_dim] = a[
+                outer_m * BLOCK_M: outer_m * BLOCK_M + inner_m_dim, outer_n * BLOCK_N: outer_n * BLOCK_N + inner_n_dim
+            ]
+    return res
+
+
+def to_block_format_with_mask(a, BLOCK_M: int, BLOCK_N: int):
+    assert a.dim() == 2
+    M, N = a.shape
+    outer_m_dim = cdiv(M, BLOCK_M)
+    outer_n_dim = cdiv(N, BLOCK_N)
+    inner_m_dim = BLOCK_M
+    inner_n_dim = BLOCK_N
+
+    res = torch.empty(
+        (outer_m_dim, outer_n_dim, inner_m_dim, inner_n_dim),
+        dtype=a.dtype,
+        device=a.device,
+    )
+
+    mask = torch.ones([outer_m_dim, outer_n_dim], device=a.device)
+
+    # TODO - Implement/check for padding
+    for m in range(outer_m_dim):
+        for n in range(outer_n_dim):
+            block = a[
+                m * BLOCK_M: (m+1) * BLOCK_M, 
+                n * BLOCK_N: (n+1) * BLOCK_N
+            ]
+            res[m, n, 0: BLOCK_M, 0: BLOCK_N] = block
+            if torch.count_nonzero(block) == 0:
+                mask[m, n] = 0
+    return (res, mask)
+
+
+def to_block_format_with_mask_bmm_one_mask(a, BLOCK_M: int, BLOCK_N: int):
+    assert a.dim() == 3
+    B, M, N = a.shape
+    outer_m_dim = cdiv(M, BLOCK_M)
+    outer_n_dim = cdiv(N, BLOCK_N)
+    inner_m_dim = BLOCK_M
+    inner_n_dim = BLOCK_N
+
+    res = torch.empty(
+        (B, outer_m_dim, outer_n_dim, inner_m_dim, inner_n_dim),
+        dtype=a.dtype,
+        device=a.device,
+    )
+
+    mask = torch.ones([outer_m_dim, outer_n_dim], device=a.device)
+
+    # TODO - Implement/check for padding
+    for m in range(outer_m_dim):
+        for n in range(outer_n_dim):
+            block = a[
+                :,
+                m * BLOCK_M: (m+1) * BLOCK_M, 
+                n * BLOCK_N: (n+1) * BLOCK_N
+            ]
+            res[:, m, n, 0: BLOCK_M, 0: BLOCK_N] = block
+            if torch.count_nonzero(block) == 0:
+                mask[m, n] = 0
+    return (res, mask)
+
+
+def to_triton_blocksparse_format(a, BLOCK_M: int, BLOCK_N: int):
+    # assert a.dim() == 3
+    assert BLOCK_M == BLOCK_N
+    
+    M, N = a.shape[-2], a.shape[-1]
+    outer_m_dim = cdiv(M, BLOCK_M)
+    outer_n_dim = cdiv(N, BLOCK_N)
+
+    mask = torch.ones([outer_m_dim, outer_n_dim], device=a.device, dtype=torch.bool)
+    mask = mask[None, :, :]
+    res = triton.testing.sparsify_tensor(a, mask, BLOCK_M)
+    return (res, mask)
+
+
+def from_block_format(a):
+    # TODO - Implement/check for padding
+    B, outer_m_dim, outer_n_dim, BLOCK_M, BLOCK_N = a.shape
+
+    M = outer_m_dim * BLOCK_M
+    N = outer_n_dim * BLOCK_N
+
+    res = torch.zeros((B, M, N), dtype=a.dtype, device=a.device)
+
+    for m in range(outer_m_dim):
+        for n in range(outer_n_dim):
+            res[
+                :,
+                m * BLOCK_M: (m+1) * BLOCK_M, 
+                n * BLOCK_N: (n+1) * BLOCK_N
+            ] = a[
+                    :, m, n, 0: BLOCK_M, 0: BLOCK_N
+                ]
+    return res
+
+
+def get_lower_triangular_mask(m, n):
+    mask = torch.tril(torch.ones([m, n], device='cuda'))
+    return mask
+
+
+def to_csr_ptrs(a, device='cuda'):
+    m, n = a.shape
+    nnz = 0
+    for i in range(m):
+        for j in range(n):
+            if a[i,j] != 0:
+                nnz += 1
+    
+    rowptrs = torch.zeros(m+1, dtype=torch.int, device=device)
+    rowptrs[0] = 0
+    cols = torch.zeros(nnz, dtype=torch.int, device=device)
+    nnz = 0
+    for i in range(m):
+        for j in range(n):
+            if a[i,j] != 0:
+                cols[nnz] = j
+                nnz += 1
+        rowptrs[i+1] = nnz
+    assert nnz == torch.sum(a)
+    return (rowptrs, cols)
+
+
+def to_ragged_format_simple(a, device='cuda'):
+    m, n = a.shape
+
+    cols = torch.empty(2*m, dtype=torch.int, device=device)
+    for i in range(m):
+        start = -1
+        end = -1
+        for j in range(n):
+            if j == 0:
+                if a[i,j] != 0:
+                    start = j
+
+            if j == n-1:
+                if a[i,j] != 0:
+                    end = j + 1
+                    continue
+
+            if a[i,j] != 0:
+                if a[i,j-1] == 0:
+                    start = j
+            elif a[i,j] == 0:
+                if a[i,j-1] != 0:
+                    end = j
+            
+        cols[2*i] = start
+        cols[2*i+1] = end
+
+    rowptrs = torch.empty(m+1, dtype=torch.int, device=device)
+    for i in range(m+1):
+        rowptrs[i] = 1
+    
+    return (rowptrs, cols)
+
+
+def gen_random_matrix(M, N, BM, BN, density=0.5, dtype=torch.float16, device='cuda'):
+    m = cdiv(M, BM)
+    n = cdiv(N, BN)
+    mask = torch.zeros([m, n], dtype=torch.int, device=device)
+    for i in range(m):
+        for j in range(n):
+            p = torch.rand(1)
+            if p[0] < density:
+                mask[i,j] = 1
+
+    nnz = torch.sum(mask)
+    data = torch.randn([nnz, BM, BN], dtype=dtype, device=device)
+    return (mask, data)
+
+
+def gen_random_matrix_dense_blocks(M, N, BM, BN, density=0.5, dtype=torch.float16, device='cuda'):
+    m = cdiv(M, BM)
+    n = cdiv(N, BN)
+    mask = torch.ones([m, n], dtype=torch.int, device=device)
+    data = torch.randn([m, n, BM, BN], dtype=dtype, device=device)
+    for i in range(m):
+        for j in range(n):
+            p = torch.rand(1)
+            if p[0] > density:
+                mask[i,j] = 0
+                data[i,j] = torch.zeros(BM, BN)
+
+    return (mask, data)
+
+
+def gen_random_mcsr_matrix(M, N, BM, BN, density=1, dtype=torch.float16, device='cuda'):
+    m = cdiv(M, BM)
+    n = cdiv(N, BN)
+    mask = torch.zeros([m, n], dtype=torch.int, device=device)
+    data = torch.randn([m, n, BM, BN], dtype=dtype, device=device)
+    for i in range(m):
+        for j in range(n):
+            p = torch.rand(1)
+            if p[0] < density:
+                mask[i,j] = 1
+            else:
+                data[i,j] = torch.zeros(BM, BN)
+
+    nnz = torch.sum(mask)
+    rowptrs = torch.zeros(m+1, dtype=torch.int, device=device)
+    rowptrs[0] = 0
+    cols = torch.zeros(nnz, dtype=torch.int, device=device)
+    
+    nnz = 0
+    for i in range(m):
+        for j in range(n):
+            if mask[i,j] != 0:
+                cols[nnz] = j
+                nnz += 1
+        rowptrs[i+1] = nnz
+    assert nnz == torch.sum(mask)
+    return BCSR(rowptrs, cols, data)
+
+
+def gen_lower_triangular_mcsr_matrix(M, N, BM, BN, dtype=torch.float16, device='cuda'):
+    m = cdiv(M, BM)
+    n = cdiv(N, BN)
+    mask = torch.ones([m, n], dtype=torch.int, device=device)
+    data = torch.randn([m, n, BM, BN], dtype=dtype, device=device)
+    for i in range(m):
+        for j in range(n):
+            if j > i:
+                data[i,j] = torch.zeros(BM, BN)
+                mask[i,j] = 0
+
+    nnz = torch.sum(mask)
+    rowptrs = torch.zeros(m+1, dtype=torch.int, device=device)
+    rowptrs[0] = 0
+    cols = torch.zeros(nnz, dtype=torch.int, device=device)
+    
+    nnz = 0
+    for i in range(m):
+        for j in range(n):
+            if mask[i,j] != 0:
+                cols[nnz] = j
+                nnz += 1
+        rowptrs[i+1] = nnz
+    assert nnz == torch.sum(mask)
+    return BCSR(rowptrs, cols, data)
+
+
+def gen_empty_matrix_dense_blocks(M, N, BM, BN, batch_size=1, dtype=torch.float16, device='cuda'):
+    m = cdiv(M, BM)
+    n = cdiv(N, BN)
+    mask = torch.ones([m, n], dtype=torch.int, device=device)
+    data = torch.empty([batch_size, m, n, BM, BN], dtype=dtype, device=device)
+    return (mask, data)
+


### PR DESCRIPTION
A few key technical points:

- `exp` is implemented using 2D partitioning where a kernel instance handles a BM x BM block. What about the zero blocks? Each kernel instance will first check if it has a valid block, and immediately return if not.
- The results of sparse `exp` is still sparse, but with different default value (1). This is handled by adding some metadata to the format, which remembers what the default value is.
- Tuning of triton kernel is done by explicit loops.

Initial row performance:

```
shape; torch.exp (in ms); our (in ms)
test dense
1x1024x1024;0.0143;0.0133
1x1024x2048;0.0195;0.0195
1x1024x4096;0.0317;0.0328
1x2048x1024;0.0195;0.0195
1x2048x2048;0.0317;0.0328
1x2048x4096;0.0553;0.0573
1x4096x1024;0.0317;0.0328
1x4096x2048;0.0553;0.0584
1x4096x4096;0.1034;0.1065
test lower tri
1x1024x1024;0.0133;0.0113
1x1024x2048;0.0195;0.0113
1x1024x4096;0.0317;0.0113
1x2048x1024;0.0195;0.0164
1x2048x2048;0.0317;0.0205
1x2048x4096;0.0563;0.0205
1x4096x1024;0.0317;0.0307
1x4096x2048;0.0563;0.0471
1x4096x4096;0.1044;0.0584
```