### PR TITLE
Initial implementation of blocksparse row-wise `sum` and its performance results

### DIFF
--- a/torchinductor/triton_ops/blocksparse/sum.py
+++ b/torchinductor/triton_ops/blocksparse/sum.py
@@ -1,0 +1,64 @@
+import sys
+import torch
+import triton 
+import triton.language as tl
+from torchinductor.triton_ops.blocksparse.utils import *
+
+
+@triton.jit
+def _sum_kernel(x_rowptrs, x_cols, x_data, y_data, 
+                M: tl.constexpr, N: tl.constexpr,
+                BM: tl.constexpr, BN: tl.constexpr,
+                TM: tl.constexpr, TN: tl.constexpr, 
+                use_dense_data: tl.constexpr
+                ):
+    inner_id = tl.program_id(0)
+    outer_id = tl.program_id(1)
+    
+    block_size = BM * BN
+
+    ## Format specific: how to get `k` would depend on the format
+    col_start = tl.load(x_cols + 2*outer_id)
+    col_end = tl.load(x_cols + 2*outer_id+1)
+
+    offsets = 0
+    ## If data layout is dense - good for debugging
+    if use_dense_data:
+        offsets += outer_id * BM * N 
+    else:
+        # TODO: add indexing for sparse data blocks
+        pass
+
+    offsets += inner_id * TM * BN + tl.arange(0, TM)[:, None] * BN + tl.arange(0, BN)[None, :]
+    x_offsets = x_data + offsets
+
+    sum = tl.zeros([TM], dtype=tl.float32)
+    for _ in range(col_start, col_end):
+        block = tl.load(x_offsets)
+        sum += tl.sum(block, axis=1)
+        x_offsets += block_size    
+
+    y_offsets = y_data + outer_id * BM + inner_id * TM + tl.arange(0, TM)
+    tl.store(y_offsets, sum)
+    
+
+def sum(x_mask: RaggedFormat, x_data, axis=1):
+    '''
+    Launch a 1D grid to do the computation (blocking rows only).
+    '''
+    if axis != 1:
+        raise Exception('Only axis=1 is supported')
+    
+    B, m, n, BM, BN = x_data.shape
+    M = m * BM
+    N = n * BN
+    y_data = torch.empty([B, M], dtype=x_data.dtype, device='cuda')
+    TM = 8  # Tunable parameter
+    grid = (BM//TM, m, B)
+    _sum_kernel[grid](
+        x_mask.rowptrs, x_mask.cols, x_data, y_data,
+        M, N, BM, BN, TM, BN, True
+    )
+    
+    return y_data
+

--- a/torchinductor/triton_ops/blocksparse/tests/test_sum.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_sum.py
@@ -1,0 +1,71 @@
+import sys
+from sentry_sdk import configure_scope
+import torch
+import triton 
+from torchinductor.triton_ops.blocksparse.utils import *
+from torchinductor.triton_ops.blocksparse.sum import sum as kernel
+
+VERBOSE = False
+
+def bench_triton(a): 
+    times = []
+    for BM in [16, 32, 64]:
+        for BN in [16, 32, 64]:
+            a_data, a_mask = to_block_format_with_mask_bmm_one_mask(a, BM, BN)
+            a_mask = RaggedFormat.from_dense_mask(a_mask)
+            b_data = kernel(a_mask, a_data)
+            b_ref = torch.sum(a, axis=-1)
+            #print(b_ref.shape, b_data.shape)
+            assert torch.allclose(b_ref, b_data), (b_ref, b_data)
+            
+            for num_warps in [2,4,8]:
+                for num_stages in [3,4]:
+                    try:
+                        ms0, _, _ = triton.testing.do_bench(lambda: kernel(a_mask, a_data), rep=50)
+                    except Exception as e:
+                        print(e)
+                    else:
+                        times.append((ms0, BM, BN, num_warps, num_stages))
+                        if VERBOSE:
+                            print((ms0, BM, BN, num_warps, num_stages))
+    times.sort(key=lambda x: x[0])
+    return times[0][0]
+
+
+def bench_kernel(a, config=''):
+    B, M, N = a.shape
+    ms0, _, _ = triton.testing.do_bench(lambda: torch.sum(a, axis=-1))
+    if VERBOSE:
+        print(f'torch: {ms0:.4f}')
+    ms1 = bench_triton(a)
+    print(config, f'{B}x{M}x{N}', f'{ms0:.4f}', f'{ms1:.4f}', sep='; ')
+
+
+def test_configs(configs):
+    dtype = torch.float32 
+    for B in [1]:
+        for M in [1024, 2048, 4096]:
+            for N in [1024, 2048, 4096]:
+                a = torch.ones([B, M, N], dtype=dtype, device='cuda')
+                if 'dense' in configs:
+                    bench_kernel(a, 'dense')
+                if 'tril' in configs:
+                    a = torch.tril(a)
+                    bench_kernel(a, 'tril')
+
+
+if '-v' in sys.argv:
+    VERBOSE = True
+
+
+configs = []
+if '--tril' in sys.argv:
+    configs.append('tril')
+if '--dense' in sys.argv:
+    configs.append('dense')
+
+test_configs(configs)
+
+'''
+Performance seems to vary significant for different block sizes.
+'''


### PR DESCRIPTION
Key points:

- Can only blocking the rows otherwise require inter-block communication.
- Each kernel instance works on `TM` rows at a time, empirically I found `TM=8` works better than `TM=1`. 

Results preview

```
dense; 1x1024x1024; 0.0164; 0.0185
dense; 1x1024x2048; 0.0207; 0.0289
dense; 1x1024x4096; 0.0358; 0.0510
dense; 1x2048x1024; 0.0195; 0.0204
dense; 1x2048x2048; 0.0297; 0.0338
dense; 1x2048x4096; 0.0533; 0.0600
dense; 1x4096x1024; 0.0275; 0.0279
dense; 1x4096x2048; 0.0457; 0.0492
dense; 1x4096x4096; 0.0785; 0.0796

tril; 1x1024x1024; 0.0164; 0.0177
tril; 1x1024x2048; 0.0204; 0.0176
tril; 1x1024x4096; 0.0351; 0.0174
tril; 1x2048x1024; 0.0184; 0.0194
tril; 1x2048x2048; 0.0297; 0.0288
tril; 1x2048x4096; 0.0525; 0.0287
tril; 1x4096x1024; 0.0284; 0.0259
tril; 1x4096x2048; 0.0460; 0.0415
tril; 1x4096x4096; 0.0765; 0.0623
```
It's slower than torch.sum for dense inputs, this is possibly due to the blocked layout which makes rows not contiguous, which might make reduction slower.

@anijain2305