### PR TITLE
Initial implementation of blocksparse `spmm` and its performance results

### DIFF
--- a/torchinductor/triton_ops/blocksparse/mmconfigs.py
+++ b/torchinductor/triton_ops/blocksparse/mmconfigs.py
@@ -1,0 +1,143 @@
+import triton
+
+basic_configs=[
+        # basic configs for compute-bound matmuls
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+        # additional configs
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=2,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=2,
+            num_warps=4,
+        ),
+        # additional configs for K = 64
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=1,
+            num_warps=2,
+        ),
+    ]
+

--- a/torchinductor/triton_ops/blocksparse/spmm.py
+++ b/torchinductor/triton_ops/blocksparse/spmm.py
@@ -1,0 +1,394 @@
+import sys
+import torch
+import triton 
+import triton.language as tl
+from torchinductor.triton_ops.blocksparse.utils import *
+
+
+@triton.jit
+def _kernel1(a_mask_rowptrs, a_cols, a_vals, b_vals, c_vals, 
+            M: tl.constexpr, K: tl.constexpr, N: tl.constexpr,
+            BM: tl.constexpr, BK: tl.constexpr, BN: tl.constexpr, 
+            nBM: tl.constexpr, nBK: tl.constexpr, nBN: tl.constexpr,
+            ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    bid = tl.program_id(2)
+
+    # pid = tl.program_id(0)
+    # bid = tl.program_id(1)
+    # m = pid // nBN
+    # n = pid % nBN
+
+    a_block_size = BM * BK
+    b_block_size = BK * BN
+    a_ptrs = a_vals + a_block_size * nBK * m + \
+        tl.arange(0, BM)[:, None] * BK + tl.arange(0, BK)[None, :]
+    b_ptrs = b_vals + b_block_size * n + \
+        tl.arange(0, BK)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    # b_cols = n * BN + tl.arange(0, BN)
+    # b_ptrs = b_vals + tl.arange(0, BK)[:, None] * N + b_cols[None, :]
+
+
+    a_ptrs += bid * M * K
+    b_ptrs += bid * K * N
+
+    #a_cols = tl.multiple_of(a_cols, 8)
+
+    k_start = tl.load(a_cols + 2*m)
+    k_end = tl.load(a_cols + 2*m+1)
+    a_ptrs = a_ptrs+a_block_size * k_start
+    b_ptrs = b_ptrs+b_block_size * nBN * k_start
+
+    c = tl.zeros((BM, BN), dtype=tl.float32)
+
+    # for k in range(nBK):
+    #     a = tl.load(a_ptrs)
+    #     b = tl.load(b_ptrs)
+    #     c += tl.dot(a, b)
+    #     a_ptrs += a_block_size
+    #     b_ptrs += b_block_size * nBN
+
+    for _ in range(k_start, k_end):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        c += tl.dot(a, b)
+        a_ptrs += a_block_size
+        b_ptrs += b_block_size * nBN
+
+    c = c.to(tl.float16)
+
+    c_ptrs = c_vals + (m * nBN + n) * BM * BN + \
+        tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    c_ptrs += bid * M * N
+    
+    tl.store(c_ptrs, c)
+
+
+def bmm1(B, M, K, N, BM, BK, BN, a_mask_rowptrs, a_cols, a_vals, b_vals, c, num_warps=4, num_stages=3):
+    nBM = cdiv(M, BM)
+    nBN = cdiv(N, BN)
+    nBK = cdiv(K, BK)
+    grid = (nBM, nBN, B)
+    binary = _kernel1[grid](a_mask_rowptrs, a_cols, a_vals, b_vals, c,
+                            M, K, N, 
+                            BM, BK, BN, nBM, nBK, nBN, 
+                            num_warps=num_warps, num_stages=num_stages
+                            )
+    #print(binary.asm['ptx'])
+    return c
+
+
+## This kernel is to test the impact of `tl.swizzle2d`, which doesn't seem to make a difference
+@triton.jit
+def _kernel2(a_cols, a_vals, b_vals, c_vals, 
+            M: tl.constexpr, K: tl.constexpr, N: tl.constexpr,
+            BM: tl.constexpr, BK: tl.constexpr, BN: tl.constexpr, 
+            nBM: tl.constexpr, nBK: tl.constexpr, nBN: tl.constexpr,
+            GROUP_SIZE_M: tl.constexpr
+            ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    bid = tl.program_id(2)
+
+    num_pid_m = tl.num_programs(0)
+    num_pid_n = tl.num_programs(1)
+    n, m = tl.swizzle2d(n, m, num_pid_n, num_pid_m, GROUP_SIZE_M)
+
+    # pid = tl.program_id(0)
+    # bid = tl.program_id(1)
+    # m = pid // nBN
+    # n = pid % nBN
+
+    a_block_size = BM * BK
+    b_block_size = BK * BN
+    a_ptrs = a_vals + a_block_size * nBK * m + \
+        tl.arange(0, BM)[:, None] * BK + tl.arange(0, BK)[None, :]
+    b_ptrs = b_vals + b_block_size * n + \
+        tl.arange(0, BK)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    # b_cols = n * BN + tl.arange(0, BN)
+    # b_ptrs = b_vals + tl.arange(0, BK)[:, None] * N + b_cols[None, :]
+
+
+    a_ptrs += bid * M * K
+    b_ptrs += bid * K * N
+
+    #a_cols = tl.multiple_of(a_cols, 8)
+
+    k_start = tl.load(a_cols + 2*m)
+    k_end = tl.load(a_cols + 2*m+1)
+    a_ptrs = a_ptrs+a_block_size * k_start
+    b_ptrs = b_ptrs+b_block_size * nBN * k_start
+
+    c = tl.zeros((BM, BN), dtype=tl.float32)
+
+    for _ in range(k_start, k_end):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        c += tl.dot(a, b)
+        a_ptrs += a_block_size
+        b_ptrs += b_block_size * nBN
+
+    c = c.to(tl.float16)
+
+    c_ptrs = c_vals + (m * nBN + n) * BM * BN + \
+        tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    c_ptrs += bid * M * N
+    
+    tl.store(c_ptrs, c)
+
+
+def bmm2(B, M, K, N, BM, BK, BN, a_cols, a_vals, b_vals, c, num_warps=4, num_stages=3):
+    nBM = cdiv(M, BM)
+    nBN = cdiv(N, BN)
+    nBK = cdiv(K, BK)
+    grid = (nBM, nBN, B)
+    binary = _kernel2[grid](a_cols, a_vals, b_vals, c,
+                            M, K, N, 
+                            BM, BK, BN, nBM, nBK, nBN, GROUP_SIZE_M=4,
+                            num_warps=num_warps, num_stages=num_stages
+                            )
+    #print(binary.asm['ptx'])
+    return c
+
+
+
+## This is to test the effect of reuse by calculating two blocks per thread.
+## Wasn't able to create a working implementation, currently buggy and don't know why
+@triton.jit
+def _kernel3(a_cols, a_vals, b_vals, c_vals, 
+            M: tl.constexpr, K: tl.constexpr, N: tl.constexpr,
+            BM: tl.constexpr, BK: tl.constexpr, BN: tl.constexpr, 
+            nBM: tl.constexpr, nBK: tl.constexpr, nBN: tl.constexpr,
+            ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    bid = tl.program_id(2)
+
+    n0 = n
+    n1 = n * 2 + 1
+
+    # pid = tl.program_id(0)
+    # bid = tl.program_id(1)
+    # m = pid // nBN
+    # n = pid % nBN
+
+    a_block_size = BM * BK
+    b_block_size = BK * BN
+    a_ptrs = a_vals + a_block_size * nBK * m + \
+        tl.arange(0, BM)[:, None] * BK + tl.arange(0, BK)[None, :]
+    b0_ptrs = b_vals + b_block_size * n0 + \
+        tl.arange(0, BK)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    # b_cols = n * BN + tl.arange(0, BN)
+    # b_ptrs = b_vals + tl.arange(0, BK)[:, None] * N + b_cols[None, :]
+
+
+    a_ptrs += bid * M * K
+    b0_ptrs += bid * K * N
+
+    #a_cols = tl.multiple_of(a_cols, 8)
+
+    k_start = tl.load(a_cols + 2*m)
+    k_end = tl.load(a_cols + 2*m+1)
+    a_ptrs = a_ptrs+a_block_size * k_start
+    b0_ptrs = b0_ptrs + b_block_size * nBN * k_start
+    
+
+    c0 = tl.zeros((BM, BN), dtype=tl.float32)
+    c1 = tl.zeros((BM, BN), dtype=tl.float32)
+
+    for _ in range(k_start, k_end):
+        a = tl.load(a_ptrs)
+        b0 = tl.load(b0_ptrs)
+        c0 += tl.dot(a, b0)
+        b1_ptrs = b0_ptrs + b_block_size
+        b1 = tl.load(b1_ptrs)
+        c1 += tl.dot(a, b1)
+        a_ptrs += a_block_size
+        b0_ptrs += b_block_size * nBN
+        
+
+    c0 = c0.to(tl.float16)
+    c1 = c1.to(tl.float16)
+
+    #c0 = c0 + c1
+
+    c0_ptrs = c_vals + (m * nBN + n0) * BM * BN + \
+        tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+    # c1_ptrs = c_vals + (m * nBN + n1) * BM * BN + \
+    #     tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    c0_ptrs += bid * M * N
+    # c1_ptrs += bid * M * N
+    
+    tl.store(c0_ptrs, c0)
+    #c1_ptrs = c0_ptrs + BM * BN
+    #tl.store(c1_ptrs, c0)
+
+
+def bmm3(B, M, K, N, BM, BK, BN, a_cols, a_vals, b_vals, c, num_warps=4, num_stages=3):
+    nBM = cdiv(M, BM)
+    nBN = cdiv(N, BN)
+    nBK = cdiv(K, BK)
+    grid = (nBM, nBN, B)
+    print('grid:', grid)
+    binary = _kernel3[grid](a_cols, a_vals, b_vals, c,
+                            M, K, N, 
+                            BM, BK, BN, nBM, nBK, nBN, 
+                            num_warps=num_warps, num_stages=num_stages
+                            )
+    #print(binary.asm['ptx'])
+    return c
+
+
+## This is to test the effect of having a CSR-ragger format. 
+## Results show that the use of two level loop seems to have a perf hit.
+@triton.jit
+def _kernel4(a_mask_rowptrs, a_cols, a_vals, b_vals, c_vals, 
+            M: tl.constexpr, K: tl.constexpr, N: tl.constexpr,
+            BM: tl.constexpr, BK: tl.constexpr, BN: tl.constexpr, 
+            nBM: tl.constexpr, nBK: tl.constexpr, nBN: tl.constexpr,
+            ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    bid = tl.program_id(2)
+
+    # pid = tl.program_id(0)
+    # bid = tl.program_id(1)
+    # m = pid // nBN
+    # n = pid % nBN
+
+    a_block_size = BM * BK
+    b_block_size = BK * BN
+    a_ptrs = a_vals + a_block_size * nBK * m + \
+        tl.arange(0, BM)[:, None] * BK + tl.arange(0, BK)[None, :]
+    b_ptrs = b_vals + b_block_size * n + \
+        tl.arange(0, BK)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    # b_cols = n * BN + tl.arange(0, BN)
+    # b_ptrs = b_vals + tl.arange(0, BK)[:, None] * N + b_cols[None, :]
+
+
+    a_ptrs += bid * M * K
+    b_ptrs += bid * K * N
+
+    #a_cols = tl.multiple_of(a_cols, 8)
+
+    row_start = tl.load(a_mask_rowptrs+m)
+    row_end = tl.load(a_mask_rowptrs+m+1)
+
+    c = tl.zeros((BM, BN), dtype=tl.float32)
+
+    for i in range(row_start, row_end, 2):
+        k_start = tl.load(a_cols + i)
+        k_end = tl.load(a_cols + i + 1)
+        a_ptrs = a_ptrs+a_block_size * k_start
+        b_ptrs = b_ptrs+b_block_size * nBN * k_start
+
+        for _ in range(k_start, k_end):
+            a = tl.load(a_ptrs)
+            b = tl.load(b_ptrs)
+            c += tl.dot(a, b)
+            a_ptrs += a_block_size
+            b_ptrs += b_block_size * nBN
+
+
+    c = c.to(tl.float16)
+
+    c_ptrs = c_vals + (m * nBN + n) * BM * BN + \
+        tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    c_ptrs += bid * M * N
+    
+    tl.store(c_ptrs, c)
+
+
+def bmm4(B, M, K, N, BM, BK, BN, a_mask_rowptrs, a_cols, a_vals, b_vals, c, num_warps=4, num_stages=3):
+    nBM = cdiv(M, BM)
+    nBN = cdiv(N, BN)
+    nBK = cdiv(K, BK)
+    grid = (nBM, nBN, B)
+    binary = _kernel4[grid](a_mask_rowptrs, a_cols, a_vals, b_vals, c,
+                            M, K, N, 
+                            BM, BK, BN, nBM, nBK, nBN, 
+                            num_warps=num_warps, num_stages=num_stages
+                            )
+    #print(binary.asm['ptx'])
+    return c
+
+
+
+## This is to test a new format, which is more general than just ragged, which uses a slow
+## path and a fast path. The fast path is ragged and the slow path is CSR (to be completed)
+@triton.jit
+def _kernel5(a_mask_rowptrs, a_cols, a_vals, b_vals, c_vals, 
+            M: tl.constexpr, K: tl.constexpr, N: tl.constexpr,
+            BM: tl.constexpr, BK: tl.constexpr, BN: tl.constexpr, 
+            nBM: tl.constexpr, nBK: tl.constexpr, nBN: tl.constexpr,
+            ):
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+    bid = tl.program_id(2)
+
+    a_block_size = BM * BK
+    b_block_size = BK * BN
+    
+    a_ptrs = a_vals + a_block_size * nBK * m + \
+        tl.arange(0, BM)[:, None] * BK + tl.arange(0, BK)[None, :]
+    b_ptrs = b_vals + b_block_size * n + \
+        tl.arange(0, BK)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    # b_cols = n * BN + tl.arange(0, BN)
+    # b_ptrs = b_vals + tl.arange(0, BK)[:, None] * N + b_cols[None, :]
+
+
+    a_ptrs += bid * M * K
+    b_ptrs += bid * K * N
+
+    #a_cols = tl.multiple_of(a_cols, 8)
+
+    k_start = tl.load(a_cols + 2*m)
+    k_end = tl.load(a_cols + 2*m+1)
+    a_ptrs = a_ptrs+a_block_size * k_start
+    b_ptrs = b_ptrs+b_block_size * nBN * k_start
+
+    c = tl.zeros((BM, BN), dtype=tl.float32)
+    for _ in range(k_end, k_start, -1):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        c += tl.dot(a, b)
+        a_ptrs += a_block_size
+        b_ptrs += b_block_size * nBN
+    c = c.to(tl.float16)
+
+    nnz = tl.load(a_mask_rowptrs+m)
+    if nnz > 1:
+        # To handle other nonzeros
+        pass
+
+
+    c_ptrs = c_vals + (m * nBN + n) * BM * BN + \
+        tl.arange(0, BM)[:, None] * BN + tl.arange(0, BN)[None, :]
+
+    c_ptrs += bid * M * N
+    
+    tl.store(c_ptrs, c)
+
+
+def bmm5(B, M, K, N, BM, BK, BN, a_mask_rowptrs, a_cols, a_vals, b_vals, c, num_warps=4, num_stages=3):
+    nBM = cdiv(M, BM)
+    nBN = cdiv(N, BN)
+    nBK = cdiv(K, BK)
+    grid = (nBM, nBN, B)
+    binary = _kernel5[grid](a_mask_rowptrs, a_cols, a_vals, b_vals, c,
+                            M, K, N, 
+                            BM, BK, BN, nBM, nBK, nBN, 
+                            num_warps=num_warps, num_stages=num_stages
+                            )
+    #print(binary.asm['ptx'])
+    return c

--- a/torchinductor/triton_ops/blocksparse/tests/test_spmm.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_spmm.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from torchinductor.triton_ops.blocksparse.utils import *
 from torchinductor.triton_ops.blocksparse.mmconfigs import basic_configs
-from torchinductor.triton_ops.blocksparse.spmm import bmm5 as kernel
+from torchinductor.triton_ops.blocksparse.spmm import bmm as kernel
 from torchinductor.triton_ops.batched_matmul import bmm_out
 
     
@@ -69,6 +69,9 @@ def test_lower_triangular(B, M, K, N, is_tril=True, runtime_log=sys.stdout):
     
 
 def test_post_shapes_lower_tri(test_dense=False):
+    '''
+    Test shapes come from post: https://fb.workplace.com/notes/172268385155581/. 
+    '''
     runtime_log = open(f'results/post.log', 'w')
     print(f'# Test post shapes, also test dense case: {test_dense}', file=runtime_log)
     shapes = [

--- a/torchinductor/triton_ops/blocksparse/tests/test_spmm.py
+++ b/torchinductor/triton_ops/blocksparse/tests/test_spmm.py
@@ -1,0 +1,145 @@
+import sys
+import argparse
+import torch
+import triton 
+import triton.language as tl
+from torchinductor.triton_ops.blocksparse.utils import *
+from torchinductor.triton_ops.blocksparse.mmconfigs import basic_configs
+from torchinductor.triton_ops.blocksparse.spmm import bmm5 as kernel
+from torchinductor.triton_ops.batched_matmul import bmm_out
+
+    
+def test_lower_triangular(B, M, K, N, is_tril=True, runtime_log=sys.stdout):
+    print(f'{B}x{M}x{K}x{N}')
+    dtype = torch.float16
+    a = torch.randn([B, M, K], dtype=dtype, device='cuda')
+    if is_tril:
+        a = torch.tril(a)
+    b = torch.randn([B, K, N], dtype=dtype, device='cuda')
+    c_ref = torch.empty([B, M, N], dtype=dtype, device='cuda')
+    torch_ms, _, _ = triton.testing.do_bench(lambda: torch.bmm(a, b, out=c_ref))
+    print(f'info: torch bmm: {torch_ms:.4f}')
+
+    triton_c_ref = torch.empty([B, M, N], dtype=dtype, device='cuda')
+    triton_ms = 0
+    triton_ms, _, _ = triton.testing.do_bench(lambda: bmm_out(a, b, triton_c_ref))
+    
+    print(f'info: triton bmm: {triton_ms:.4f}')
+    print(torch.allclose(c_ref, triton_c_ref, atol=0.1, rtol=0.01))
+
+    times = []
+    for config in basic_configs:
+        BM = config.kwargs['BLOCK_M']
+        BN = config.kwargs['BLOCK_N']
+        BK = config.kwargs['BLOCK_K']
+  
+        if BM > M or BK > K or BN > N:
+            continue
+        num_stages = config.num_stages
+        num_warps = config.num_warps
+        print(f'info: blocks: {BM} x {BK} x {BN}')
+        a_block, a_mask = to_block_format_with_mask_bmm_one_mask(a, BM, BK)
+        a_mask = RaggedFormat.from_dense_mask(a_mask)
+        a_mask_rowptrs, a_mask_cols = a_mask.rowptrs, a_mask.cols
+        
+        #print(a_mask_rowptrs)
+        
+        b_block, b_mask = to_block_format_with_mask_bmm_one_mask(b, BK, BN)
+        c = gen_empty_matrix_dense_blocks(M, N, BM, BN, batch_size=B)
+
+        ms = torch.inf
+        try:
+            ms, _, _ = triton.testing.do_bench(lambda: 
+                kernel(B, M, K, N, BM, BK, BN, a_mask_rowptrs, a_mask_cols, a_block, b_block, c[1], num_warps, num_stages), 
+            rep=50)
+            print(f'info: {num_stages} x {num_warps}, {ms:.4f}')
+            
+        except Exception as e:
+            print('info: run triton failed ({BM} x {BK} x {BN})')
+            print(type(e))
+            print(e)
+        verified = torch.allclose(c_ref, from_block_format(c[1]))
+        print('info: verify passes:', verified)
+        if verified:
+            times.append((ms, BM, BK, BN, num_stages, num_warps))
+    times.sort(key=lambda x: x[0])
+    best_time = times[0][0]
+    print(f'{B}x{M}x{K}x{N}', f'{torch_ms:.4f}', f'{triton_ms:.4f}', f'{best_time:.4f}', sep='; ', file=runtime_log)
+    runtime_log.flush()
+    
+
+def test_post_shapes_lower_tri(test_dense=False):
+    runtime_log = open(f'results/post.log', 'w')
+    print(f'# Test post shapes, also test dense case: {test_dense}', file=runtime_log)
+    shapes = [
+        (32*16, 1024, 1024, 1024//16),
+        (32*16, 1024, 1024, 4096//16),
+        (32*16, 1024, 1024, 8192//16),
+        (32*16, 2048, 2048, 1024//16),
+        (32*16, 2048, 2048, 4096//16),
+        (32*16, 2048, 2048, 8192//16),
+    ]
+    for shape in shapes:
+        B, M, K, N = shape
+        test_lower_triangular(B, M, K, N, runtime_log=runtime_log)
+
+    if test_dense:
+        for shape in shapes:
+            B, M, K, N = shape
+            test_lower_triangular(B, M, K, N, False, runtime_log=runtime_log)
+    runtime_log.close()
+
+
+def test_single_batch():
+    shapes = [
+        (1, 1024, 1024, 1024),
+        (1, 1024, 1024, 4096),
+        (1, 1024, 1024, 8192),
+        (1, 2048, 2048, 1024//16),
+        (1, 2048, 2048, 4096//16),
+        (1, 2048, 2048, 8192//16),
+        (1, 4096, 4096, 4096),
+        (1, 8192, 8192, 8192),
+    ]
+    
+
+def test_torchbench_shapes(test_dense=False):
+    runtime_log = open(f'results/torchbench.log', 'w')
+    print(f'# Test torchbench shapes, also test dense case: {test_dense}', file=runtime_log)
+    shapes = [
+        (192, 128, 64, 128),
+        (192, 128, 128, 64),
+        (12, 1024, 1024, 64),
+        (12, 1024, 64, 1024),
+        (12, 512, 64, 512),
+        (12, 512, 512, 64),
+    ]
+    for shape in shapes:
+        B, M, K, N = shape
+        test_lower_triangular(B, M, K, N, runtime_log=runtime_log)
+
+    if test_dense:
+        for shape in shapes:
+            B, M, K, N = shape
+            test_lower_triangular(B, M, K, N, False, runtime_log=runtime_log)
+    runtime_log.close()
+
+
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('-m', type=int, default=0)
+parser.add_argument('-k', type=int)
+parser.add_argument('-n', type=int)
+parser.add_argument('-b', type=int)
+parser.add_argument('-t', type=str, default="")
+args = parser.parse_args()
+
+B, M, K, N = args.b, args.m, args.k, args.n
+
+if args.t == 'post':
+    test_post_shapes_lower_tri()
+elif args.t == 'torchbench':
+    test_torchbench_shapes(True)
+else:
+    test_lower_triangular(B, M, K, N)
+


### PR DESCRIPTION
Key points:
- Tried various formats, design decisions are explained in [post](fb.workplace.com/notes/141510448550237/)
- Implemented multiple variants of the final kernel to understand the performance implication of several factors. 
- All kernels are implemented as bmm and assume 3D inputs. For matrices, the first dim is 1. 

Results:
- Tested using two sets of shapes, one from this [post](https://fb.workplace.com/notes/172268385155581/) and another one from torchbench.
dense mask:
![image](https://user-images.githubusercontent.com/7697776/180074161-fa613e9c-4138-4bdb-919e-58aed4afc779.png)

lower triangular mask:
![image](https://user-images.githubusercontent.com/7697776/180074282-9265eed3-0cfb-4330-b208-9fdd122c0189.png)

@anijain2305. cc @jansel @desertfire



